### PR TITLE
Adjust movement to allow for variable speed

### DIFF
--- a/inc/player.h
+++ b/inc/player.h
@@ -26,14 +26,16 @@
 #include <genesis.h>
 
 typedef struct {
+  V2f16 position;
   Sprite* sprite;
-  V2s16 position;
-  u8 attackCooldown;
   f16 bankDirection;
+  u8 attackCooldown;
   bool isInvulnerable;
 } Player;
 
 void initPlayer();
+
+Player* createPlayer(s16 _x, s16 _y, u16 _palette);
 
 void setUpPlayer(Player* _player, s16 _x, s16 _y, u16 _palette);
 
@@ -41,4 +43,6 @@ void updatePlayer(Player* _player);
 
 void tearDownPlayer(Player* _player);
 
-#endif  // __QUANTUM_BURST_GAME_H__
+void destroyPlayer(Player* _player);
+
+#endif  // __QUANTUM_BURST_PLAYER_H__

--- a/inc/utilities.h
+++ b/inc/utilities.h
@@ -25,6 +25,11 @@
 
 #include <genesis.h>
 
+#define PAL_FRAME_RATE 50
+#define NTSC_FRAME_RATE 60
+
+#define clamp(X, L, H) (min(max((X), (L)), (H)))
+
 void showText(char _text[], u8 _column);
 
 void clearText(u8 _column);

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -21,12 +21,8 @@
 // SOFTWARE.
 
 #include <genesis.h>
-#include <string.h>
 
 #include "utilities.h"
-
-#define PAL_FRAME_RATE 50
-#define NTSC_FRAME_RATE 60
 
 void showText(char _text[], u8 _column) {
   VDP_drawText(_text, 20 - strlen(_text) / 2, _column);


### PR DESCRIPTION
This adjust player movement and other related items to use `fix16` as well as a frame rate based movement model to allow for the same timing of movement regardless of **PAL** or **NTSC** hardware.