### PR TITLE
Add auto clean-up for managed actors

### DIFF
--- a/inc/actor.h
+++ b/inc/actor.h
@@ -52,6 +52,11 @@ Actor* createActor(V2f32 _position, void* _data,
                    ActorDrawCallback _drawCallback,
                    ActorDestroyCallback _destroyCallback);
 
+void setUpActor(Actor* _actor, V2f32 _position, void* _data,
+                ActorUpdateCallback _updateCallback,
+                ActorDrawCallback _drawCallback,
+                ActorDestroyCallback _destroyCallback);
+
 void updateActor(Actor* _actor, const Stage* _stage);
 
 void drawActor(const Actor* _actor, const Camera* _camera);

--- a/inc/managed-actor.h
+++ b/inc/managed-actor.h
@@ -29,32 +29,23 @@
 #include "camera.h"
 #include "stage.h"
 
-// entity
-
-struct _ManagedActor;
-typedef struct _ManagedActor ManagedActor;
-
-struct _ManagedActor {
-  Actor actor;
-  ManagedActor* previous;
-  ManagedActor* next;
-};
-
 // life-cycle
+
+void initManagedActors();
 
 void createManagedActor(V2f32 _position, void* _data,
                         ActorUpdateCallback _updateCallback,
                         ActorDrawCallback _drawCallback,
                         ActorDestroyCallback _destroyCallback);
 
-// life-cycle
-
-void initManagedActors();
-
 void updateManagedActors(const Stage* _stage);
 
 void drawManagedActors(const Camera* _camera);
 
 void destroyManagedActors();
+
+// properties
+
+void setManagedActorCleanUp(Actor* _actor);
 
 #endif  // __QUANTUM_BURST_MANAGED_ACTOR_H__

--- a/src/actor.c
+++ b/src/actor.c
@@ -32,13 +32,21 @@ Actor* createActor(V2f32 _position, void* _data,
                    ActorDestroyCallback _destroyCallback) {
   Actor* actor = malloc(sizeof(Actor));
 
-  actor->position = _position;
-  actor->data = _data;
-  actor->updateCallback = _updateCallback;
-  actor->drawCallback = _drawCallback;
-  actor->destroyCallback = _destroyCallback;
+  setUpActor(actor, _position, _data, _updateCallback, _drawCallback,
+             _destroyCallback);
 
   return actor;
+}
+
+void setUpActor(Actor* _actor, V2f32 _position, void* _data,
+                ActorUpdateCallback _updateCallback,
+                ActorDrawCallback _drawCallback,
+                ActorDestroyCallback _destroyCallback) {
+  _actor->position = _position;
+  _actor->data = _data;
+  _actor->updateCallback = _updateCallback;
+  _actor->drawCallback = _drawCallback;
+  _actor->destroyCallback = _destroyCallback;
 }
 
 void updateActor(Actor* _actor, const Stage* _stage) {

--- a/src/actors/enemies/homing-mine.c
+++ b/src/actors/enemies/homing-mine.c
@@ -73,6 +73,7 @@ static void update(Actor* _actor, const Stage* _stage) {
   if (magnitude <= explodeRadius) {
     exploded = TRUE;
 
+    setManagedActorCleanUp(_actor);
     doPlayerHit(player);
   } else if (magnitude <= homingRadius) {
     const f32 speedX = fix32Mul(fix32Div(deltaX, magnitude), g_homingMineSpeed);

--- a/src/actors/enemies/mine.c
+++ b/src/actors/enemies/mine.c
@@ -64,6 +64,7 @@ static void update(Actor* _actor, const Stage* _stage) {
   if (magnitude <= explodeRadius) {
     exploded = TRUE;
 
+    setManagedActorCleanUp(_actor);
     doPlayerHit(player);
   }
 


### PR DESCRIPTION
You can now call setManagedActorCleanUp to mark a ManagedActor as ready for clean-up on the next update pass. This will not work on the normal Actor.