### PR TITLE
Build sgdk lib as part of build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,10 +37,15 @@ try {
     }
   }
 
-  # run build
-  Set-Location $gameRoot
-
+  # build lib
   $sgdkRoot = Join-Path $externalsRoot sgdk
+
+  Set-Location $sgdkRoot
+
+  & "$sgdkRoot\bin\make" -f "$sgdkRoot\makelib.gen"
+
+  # build game
+  Set-Location $gameRoot
 
   if ($isBuild -And $rebuild) {
     & "$sgdkRoot\bin\make" -f "$sgdkRoot\makefile.gen" clean


### PR DESCRIPTION
Often the sgdk external has changes made to it's source files but the built lib is not updated. This now builds the lib as part of the build script before building the game code to ensure it's the latest code.